### PR TITLE
feat: linked skills by skill

### DIFF
--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -40,6 +40,8 @@ export const typeDefs = gql`
     linkedFromCategories(skillName: String!): [Category!]!
     # Get distinct categories of skills linked *to* a specific skill
     linkedToCategories(skillName: String!): [Category!]!
+    # Get all skills linked from a specific skill (without category filtering)
+    linkedSkills(skillName: String!): [Skill!]!
   }
 `;
 
@@ -52,6 +54,11 @@ export const resolvers = {
     skill: async (_: unknown, { name }: { name: string }) => findSkillByName(name),
     linkedFromCategories: async (_: unknown, { skillName }: { skillName: string }) => findLinkedFromCategories(skillName),
     linkedToCategories: async (_: unknown, { skillName }: { skillName: string }) => findLinkedToCategories(skillName),
+    linkedSkills: async (_: unknown, { skillName }: { skillName: string }) => {
+      const skill = await findSkillByName(skillName);
+      if (!skill) return [];
+      return findSkillsLinkedFrom(skillName);
+    },
   },
   // Resolvers for nested fields within Types, calling repository functions
   Skill: {

--- a/backend/src/test/graphql.test.ts
+++ b/backend/src/test/graphql.test.ts
@@ -163,6 +163,37 @@ describe('GraphQL Schema', () => {
       const categoryNames = result.data?.linkedFromCategories.map((c: CategoryType) => c.name);
       expect(categoryNames).toEqual(expect.arrayContaining(expectedCategories));
     });
+    
+    test('linkedSkills query returns all skills linked from a skill (without category filtering)', async () => {
+      const skillName = '裏拳';
+      
+      // Find all skills linked from '裏拳'
+      const expectedLinkedSkills = testLinkage
+        .filter(link => link.sourceSkill === skillName)
+        .map(link => link.targetSkill);
+      
+      const query = `
+        query GetAllLinkedSkills($skillName: String!) {
+          linkedSkills(skillName: $skillName) {
+            name
+            category {
+              name
+            }
+          }
+        }
+      `;
+      
+      const result = await server.executeOperation({
+        query,
+        variables: { skillName },
+      });
+      
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.linkedSkills).toHaveLength(expectedLinkedSkills.length);
+      
+      const linkedSkillNames = result.data?.linkedSkills.map((s: SkillType) => s.name);
+      expect(linkedSkillNames).toEqual(expect.arrayContaining(expectedLinkedSkills));
+    });
   });
   
   describe('Nested resolvers', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new GraphQL query to retrieve all skills linked from a specified skill.

- **Tests**
  - Introduced a test case to verify the new linked skills query and its expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->