### PR TITLE
fix: dont stack skill when clicking center skill

### DIFF
--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -13,6 +13,7 @@
 - [x] fix: add same skill to linked box
 - [x] fix: add first skill to linked box
 - [x] other: remove list display
+- [x] fix: don't stack skill when clicking center skill
 - [] feat: show badge when selecting categories
 - [] feat: reverse search
 - [] feat: sort categories

--- a/frontend/src/features/skillChaining/components/visualization/CategorySkillsGraph.tsx
+++ b/frontend/src/features/skillChaining/components/visualization/CategorySkillsGraph.tsx
@@ -48,7 +48,7 @@ SkillNode.displayName = 'SkillNode';
 
 interface CategorySkillsGraphProps {
   category: string;
-  onSkillSelect: (skillName: string) => void;
+  onSkillSelect: (skillName: string, shouldAddToChain: boolean) => void;
 }
 
 export function CategorySkillsGraph({ 
@@ -84,7 +84,7 @@ export function CategorySkillsGraph({
 
   // ノードクリックハンドラ
   const onNodeClick = (_: React.MouseEvent, node: Node) => {
-    onSkillSelect(node.id as string);
+    onSkillSelect(node.id as string, true); // カテゴリグラフからのスキル選択は常に連携に追加する
   };
 
   if (loading) return <div className="loading-container"><LoadingIndicator /></div>;

--- a/frontend/src/features/skillChaining/components/visualization/SkillFlowChart.tsx
+++ b/frontend/src/features/skillChaining/components/visualization/SkillFlowChart.tsx
@@ -58,7 +58,7 @@ SkillNode.displayName = 'SkillNode';
 interface SkillFlowChartProps {
   skillName: string;
   selectedCategories?: string[];
-  onSkillSelect?: (skillName: string) => void;
+  onSkillSelect?: (skillName: string, shouldAddToChain: boolean) => void;
 }
 
 export function SkillFlowChart({ 
@@ -156,7 +156,7 @@ export function SkillFlowChart({
     // 中心ノード（選択されたスキル）
     // 中心スキルのリンク数はlinkedSkillsの長さ（このスキルからリンクしているスキル数）
     const centerNode: Node = {
-      id: sourceSkillName,
+      id: `source_${sourceSkillName}`, // ソース/起点としての接頭辞を追加
       type: 'skillNode', // カスタムノードタイプを指定
       data: { 
         label: sourceSkillName,
@@ -288,8 +288,11 @@ export function SkillFlowChart({
       if (typeof clickedSkillName === 'string') {
         console.log(`スキル選択: ${clickedSkillName}`);
         
+        // ノードのIDに「source_」が含まれているかで判断
+        const shouldAddToChain = !node.id.toString().startsWith('source_');
+        
         if (onSkillSelect) {
-          onSkillSelect(clickedSkillName);
+          onSkillSelect(clickedSkillName, shouldAddToChain);
         }
       } else {
         console.warn('無効なスキル名でクリックされました:', node);

--- a/frontend/src/features/skillChaining/components/visualization/StackedSkills.tsx
+++ b/frontend/src/features/skillChaining/components/visualization/StackedSkills.tsx
@@ -10,7 +10,7 @@ interface SkillItem {
 
 interface StackedSkillsProps {
   allSkills: SkillItem[];
-  onSkillClick?: (skillName: string) => void;
+  onSkillClick?: (skillName: string, shouldAddToChain?: boolean) => void;
 }
 
 export function StackedSkills({ allSkills, onSkillClick }: StackedSkillsProps) {
@@ -35,8 +35,9 @@ export function StackedSkills({ allSkills, onSkillClick }: StackedSkillsProps) {
     dispatch({ type: 'SELECT_STACK_SKILL', payload: index });
     
     // 選択したスキルの詳細ビューを表示する場合
+    // スタック内でクリックした場合は常にチェーンに追加しない
     if (onSkillClick) {
-      onSkillClick(skillName);
+      onSkillClick(skillName, false);
     }
   }, [dispatch, onSkillClick]);
   

--- a/frontend/src/features/skillChaining/components/visualization/VisualizationContent.tsx
+++ b/frontend/src/features/skillChaining/components/visualization/VisualizationContent.tsx
@@ -14,7 +14,7 @@ interface VisualizationContentProps {
   graphSkill: string | null;
   selectedCategories: string[];
   allCategories: string[];
-  onSkillSelect: (skillName: string) => void;
+  onSkillSelect: (skillName: string, shouldAddToChain: boolean) => void;
 }
 
 export const VisualizationContent: React.FC<VisualizationContentProps> = ({
@@ -53,8 +53,8 @@ export const VisualizationContent: React.FC<VisualizationContentProps> = ({
   };
 
   // スキル選択ハンドラ
-  const handleSkillSelect = (skillName: string) => {
-    onSkillSelect(skillName);
+  const handleSkillSelect = (skillName: string, shouldAddToChain: boolean = true) => {
+    onSkillSelect(skillName, shouldAddToChain);
     setDisplayMode(DisplayMode.FLOWCHART);
   };
 

--- a/frontend/src/features/skillChaining/pages/SkillChainVisualization.tsx
+++ b/frontend/src/features/skillChaining/pages/SkillChainVisualization.tsx
@@ -38,11 +38,15 @@ export function SkillChainVisualization() {
   }, [categories]);
   
   // スキル選択ハンドラー
-  const handleSelectSkill = (skillName: string) => {
+  const handleSelectSkill = (skillName: string, shouldAddToChain: boolean = true) => {
     setGraphSkill(skillName);
     
-    // 同じスキルも複数回追加できるようにする (例: 骨砕き > 骨砕き)
-    dispatch({ type: 'ADD_SKILL', payload: skillName });
+    // 連携チェーンに追加すべき場合のみスタックに追加する
+    // これにより、中央ノード（現在表示中のスキル）をクリックしても追加されなくなる
+    if (shouldAddToChain) {
+      // 同じスキルも複数回追加できるようにする (例: 骨砕き > 骨砕き)
+      dispatch({ type: 'ADD_SKILL', payload: skillName });
+    }
   };
 
   // カテゴリ削除ハンドラー


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where clicking the center skill would incorrectly stack the skill, ensuring only appropriate skills are added to the chain.
- **Documentation**
  - Updated the TODO list to reflect the completed fix regarding skill stacking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->