### PR TITLE
add order to categories

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,8 @@ docker compose up -d
 ### 2. 初期データの投入
 
 ```bash
-docker exec -i sf2-neo4j cypher-shell -u neo4j -p '' -f /var/lib/neo4j/import/init.cypher
+docker exec sf2-neo4j cypher-shell -f /var/lib/neo4j/import/init.cypher
+docker exec sf2-neo4j cypher-shell -f /var/lib/neo4j/import/categories_order.cypher
 ```
 
 ---

--- a/backend/src/model/Category.ts
+++ b/backend/src/model/Category.ts
@@ -4,9 +4,11 @@ import { CategoryType, SkillType } from './types';
 export class Category implements CategoryType {
   name: string;
   skills: SkillType[];
+  order: number;
 
-  constructor(name: string, skills: SkillType[] = []) {
+  constructor(name: string, skills: SkillType[] = [], order: number = 0) {
     this.name = name;
     this.skills = skills;
+    this.order = order;
   }
 }

--- a/backend/src/model/types.ts
+++ b/backend/src/model/types.ts
@@ -9,4 +9,5 @@ export interface SkillType {
 export interface CategoryType {
   name: string;
   skills: SkillType[];
+  order: number;
 }

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -17,6 +17,7 @@ export const typeDefs = gql`
   type Category {
     name: String!
     skills: [Skill!]! # Skills belonging to this category
+    order: Int!
   }
 
   type Skill {

--- a/backend/src/test/mock/repositoryMock.ts
+++ b/backend/src/test/mock/repositoryMock.ts
@@ -11,7 +11,8 @@ export function setupRepositoryMocks() {
   // Mock the repository functions directly to avoid session.close() issues
   jest.spyOn(repository, 'findAllCategories').mockImplementation(async (): Promise<CategoryType[]> => {
     return testCategories.map(cat => ({ 
-      name: cat.name, 
+      name: cat.name,
+      order: cat.order,
       skills: [] 
     }));
   });
@@ -20,7 +21,8 @@ export function setupRepositoryMocks() {
     const category = testCategories.find(c => c.name === name);
     if (!category) return null;
     return { 
-      name: category.name, 
+      name: category.name,
+      order: category.order, 
       skills: [] 
     };
   });
@@ -61,7 +63,8 @@ export function setupRepositoryMocks() {
     if (!category) return null;
     
     return { 
-      name: category.name, 
+      name: category.name,
+      order: category.order, 
       skills: [] 
     };
   });
@@ -94,10 +97,14 @@ export function setupRepositoryMocks() {
     const targetSkills = testSkills.filter(skill => targetSkillNames.includes(skill.name));
     const categoryNames = [...new Set(targetSkills.map(skill => skill.categoryName))];
     
-    return categoryNames.map(name => ({ 
-      name, 
-      skills: [] 
-    }));
+    return categoryNames.map(name => {
+      const category = testCategories.find(c => c.name === name);
+      return { 
+        name, 
+        order: category?.order || 0,
+        skills: [] 
+      };
+    });
   });
 
   jest.spyOn(repository, 'findLinkedToCategories').mockImplementation(async (skillName: string): Promise<CategoryType[]> => {
@@ -106,10 +113,14 @@ export function setupRepositoryMocks() {
     const sourceSkills = testSkills.filter(skill => sourceSkillNames.includes(skill.name));
     const categoryNames = [...new Set(sourceSkills.map(skill => skill.categoryName))];
     
-    return categoryNames.map(name => ({ 
-      name, 
-      skills: [] 
-    }));
+    return categoryNames.map(name => {
+      const category = testCategories.find(c => c.name === name);
+      return { 
+        name, 
+        order: category?.order || 0,
+        skills: [] 
+      };
+    });
   });
 
   // Leave getDriver mocked as a no-op since we're bypassing it

--- a/backend/src/test/setup/testData.ts
+++ b/backend/src/test/setup/testData.ts
@@ -5,9 +5,9 @@ import { CategoryType } from '../../model/types';
  * Test data for categories
  */
 export const testCategories: Omit<CategoryType, 'skills'>[] = [
-  { name: '体' }, // Body technique category
-  { name: '剣' }, // Sword category
-  { name: '斧' }, // Axe category
+  { name: '体', order: 1 }, // Body technique category
+  { name: '剣', order: 3 }, // Sword category
+  { name: '斧', order: 5 }, // Axe category
 ];
 
 /**

--- a/neo4j/init/categories_order.cypher
+++ b/neo4j/init/categories_order.cypher
@@ -1,0 +1,31 @@
+// categories_order.cypher
+// This script adds order properties to category nodes
+// Run this script after init.cypher has created the categories
+
+// Create index on Category.order for better query performance
+CREATE INDEX FOR (c:Category) ON (c.order);
+
+// Set order for weapon-type categories
+MATCH (c:Category {name: '体'}) SET c.order = 1;
+MATCH (c:Category {name: '杖'}) SET c.order = 2;
+MATCH (c:Category {name: '剣'}) SET c.order = 3;
+MATCH (c:Category {name: '槍'}) SET c.order = 4;
+MATCH (c:Category {name: '斧'}) SET c.order = 5;
+MATCH (c:Category {name: '弓'}) SET c.order = 6;
+
+// Set order for magical categories
+MATCH (c:Category {name: '合成術'}) SET c.order = 7;
+MATCH (c:Category {name: '基本術'}) SET c.order = 8;
+MATCH (c:Category {name: '固有術'}) SET c.order = 9;
+
+// Set order for other categories
+MATCH (c:Category {name: '固有技'}) SET c.order = 10;
+MATCH (c:Category {name: '敵'}) SET c.order = 11;
+
+// Set order for empty category (lowest priority, shown last)
+MATCH (c:Category {name: ''}) SET c.order = 99;
+
+// Verify categories have been updated
+MATCH (c:Category)
+RETURN c.name, c.order
+ORDER BY c.order;

--- a/neo4j/init/categories_order.cypher
+++ b/neo4j/init/categories_order.cypher
@@ -5,25 +5,29 @@
 // Create index on Category.order for better query performance
 CREATE INDEX FOR (c:Category) ON (c.order);
 
-// Set order for weapon-type categories
-MATCH (c:Category {name: '体'}) SET c.order = 1;
-MATCH (c:Category {name: '杖'}) SET c.order = 2;
-MATCH (c:Category {name: '剣'}) SET c.order = 3;
-MATCH (c:Category {name: '槍'}) SET c.order = 4;
-MATCH (c:Category {name: '斧'}) SET c.order = 5;
-MATCH (c:Category {name: '弓'}) SET c.order = 6;
+// Batch set orders for all categories using UNWIND for better maintainability
+UNWIND [
+  {name: '体', order: 1},     // Body technique category
+  {name: '杖', order: 2},     // Staff category
+  {name: '剣', order: 3},     // Sword category
+  {name: '槍', order: 4},     // Spear category
+  {name: '斧', order: 5},     // Axe category
+  {name: '弓', order: 6},     // Bow category
+  {name: '合成術', order: 7}, // Synthesis magic category
+  {name: '基本術', order: 8}, // Basic magic category
+  {name: '固有術', order: 9}, // Unique magic category
+  {name: '固有技', order: 10}, // Unique skill category
+  {name: '敵', order: 11},    // Enemy category
+  {name: '', order: 99}       // Empty category (lowest priority)
+] AS cat
+MATCH (c:Category {name: cat.name})
+WHERE c.order IS NULL
+SET c.order = cat.order;
 
-// Set order for magical categories
-MATCH (c:Category {name: '合成術'}) SET c.order = 7;
-MATCH (c:Category {name: '基本術'}) SET c.order = 8;
-MATCH (c:Category {name: '固有術'}) SET c.order = 9;
-
-// Set order for other categories
-MATCH (c:Category {name: '固有技'}) SET c.order = 10;
-MATCH (c:Category {name: '敵'}) SET c.order = 11;
-
-// Set order for empty category (lowest priority, shown last)
-MATCH (c:Category {name: ''}) SET c.order = 99;
+// Set a default order for any new categories without an order
+MATCH (c:Category)
+WHERE c.order IS NULL
+SET c.order = 100;
 
 // Verify categories have been updated
 MATCH (c:Category)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an explicit ordering property for categories, enabling sorting by a defined order in addition to name.
  - The GraphQL API and related data structures now include an integer order field for each category.

- **Documentation**
  - Updated README instructions for loading initial data into the Neo4j database, splitting the process into two steps.

- **Tests**
  - Enhanced test data and mocks to support the new category order property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->