### PR TITLE
add order to frontend query and hooks

### DIFF
--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -20,6 +20,8 @@
 - [x] feat: sort by categories
 - [x] feat: filter minor categories
 - [] feat: sort skills by cateogry
+　- [] feat: frontend query and type
+　- [] feat: sort on graph
 - [] feat: show badge when selecting categories
 - [] feat: batch cost
 - [] feat: sort skills by category and cost

--- a/frontend/src/api/graphql/queries.ts
+++ b/frontend/src/api/graphql/queries.ts
@@ -5,6 +5,7 @@ export const GET_CATEGORIES = gql`
   query GetCategories {
     categories {
       name
+      order
     }
   }
 `;
@@ -14,6 +15,7 @@ export const GET_SKILLS_BY_CATEGORY = gql`
   query GetSkillsByCategory($categoryName: String!) {
     category(name: $categoryName) {
       name
+      order
       skills {
         name
       }
@@ -29,6 +31,7 @@ export const GET_SKILL_LINKED_CATEGORIES = gql`
     }
     linkedFromCategories(skillName: $skillName) {
       name
+      order
     }
   }
 `;
@@ -50,6 +53,7 @@ export const GET_LINKED_SKILLS_BY_CATEGORY = gql`
     }
     category(name: $categoryName) {
       name
+      order
     }
   }
 `;
@@ -61,6 +65,7 @@ export const GET_LINKED_SKILLS = gql`
       name
       category {
         name
+        order
       }
       linksTo {
         name

--- a/frontend/src/api/hooks/useCategories.ts
+++ b/frontend/src/api/hooks/useCategories.ts
@@ -1,13 +1,23 @@
 import { useQuery } from '@apollo/client';
+import { useMemo } from 'react';
 import { GET_CATEGORIES } from '../graphql/queries';
 import { CategoriesQueryResult } from '../types';
 
 export function useCategories() {
   const { loading, error, data } = useQuery<CategoriesQueryResult>(GET_CATEGORIES);
   
+  const sortedCategories = useMemo(() => {
+    if (!data?.categories) return [];
+    
+    // Create a copy and sort by order (fallback to 999 if order is undefined)
+    return [...data.categories].sort((a, b) => 
+      (a.order ?? 999) - (b.order ?? 999)
+    );
+  }, [data]);
+  
   return {
     loading,
     error,
-    categories: data?.categories || []
+    categories: sortedCategories
   };
 }

--- a/frontend/src/api/hooks/useLinkedCategories.ts
+++ b/frontend/src/api/hooks/useLinkedCategories.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { useMemo } from 'react';
 import { GET_SKILL_LINKED_CATEGORIES } from '../graphql/queries';
 import { LinkedFromCategoriesQueryResult } from '../types';
 
@@ -11,9 +12,18 @@ export function useLinkedCategories(skillName: string | null) {
     }
   );
   
+  const sortedLinkedCategories = useMemo(() => {
+    if (!data?.linkedFromCategories) return [];
+    
+    // Create a copy and sort by order (fallback to 999 if order is undefined)
+    return [...data.linkedFromCategories].sort((a, b) => 
+      (a.order ?? 999) - (b.order ?? 999)
+    );
+  }, [data]);
+  
   return {
     loading,
     error,
-    linkedCategories: data?.linkedFromCategories || []
+    linkedCategories: sortedLinkedCategories
   };
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2,6 +2,7 @@
 
 export interface Category {
   name: string;
+  order?: number;
   skills?: Skill[];
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Categories and linked categories are now sorted by their order, improving the display sequence across the app.

- **Documentation**
  - Added two new todo items related to frontend query/type and sorting on the graph.

- **Style**
  - No user-facing style changes, but category ordering is now more consistent.

These changes enhance the organization and clarity of category listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->