### PR TITLE
add order to skill queries

### DIFF
--- a/backend/src/test/graphql.test.ts
+++ b/backend/src/test/graphql.test.ts
@@ -241,10 +241,10 @@ describe('GraphQL Schema', () => {
       expect(result.data?.linkedSkills).toHaveLength(expectedLinkedSkills.length);
       
       // Check each linked skill has its category order correctly set
-      result.data?.linkedSkills.forEach((skill: any) => {
+      result.data?.linkedSkills.forEach((skill: SkillType) => {
         const expectedSkill = expectedLinkedSkills.find(e => e.name === skill.name);
-        expect(skill.category.name).toBe(expectedSkill?.categoryName);
-        expect(skill.category.order).toBe(expectedSkill?.categoryOrder);
+        expect(skill.category!.name).toBe(expectedSkill?.categoryName);
+        expect(skill.category!.order).toBe(expectedSkill?.categoryOrder);
       });
     });
   });

--- a/backend/src/test/graphql.test.ts
+++ b/backend/src/test/graphql.test.ts
@@ -26,11 +26,12 @@ describe('GraphQL Schema', () => {
   });
   
   describe('Queries', () => {
-    test('categories query returns all categories', async () => {
+    test('categories query returns all categories with order field', async () => {
       const query = `
         query {
           categories {
             name
+            order
           }
         }
       `;
@@ -42,6 +43,14 @@ describe('GraphQL Schema', () => {
       
       const categoryNames = result.data?.categories.map((c: CategoryType) => c.name);
       expect(categoryNames).toEqual(expect.arrayContaining(testCategories.map(c => c.name)));
+      
+      // Verify order field is present and matches expected values
+      const resultCategoriesMap = new Map(result.data?.categories.map((c: CategoryType) => [c.name, c]));
+      testCategories.forEach(testCat => {
+        const resultCat = resultCategoriesMap.get(testCat.name) as CategoryType;
+        expect(resultCat).toBeDefined();
+        expect(resultCat.order).toBe(testCat.order);
+      });
     });
     
     test('category query returns a specific category', async () => {
@@ -194,12 +203,58 @@ describe('GraphQL Schema', () => {
       const linkedSkillNames = result.data?.linkedSkills.map((s: SkillType) => s.name);
       expect(linkedSkillNames).toEqual(expect.arrayContaining(expectedLinkedSkills));
     });
+
+    test('linkedSkills query returns linked skills with category order', async () => {
+      const skillName = '裏拳';
+      
+      // Find all skills linked from '裏拳'
+      const expectedLinkedSkills = testLinkage
+        .filter(link => link.sourceSkill === skillName)
+        .map(link => {
+          const targetSkill = testSkills.find(s => s.name === link.targetSkill);
+          const category = testCategories.find(c => c.name === targetSkill?.categoryName);
+          return {
+            name: link.targetSkill,
+            categoryName: targetSkill?.categoryName,
+            categoryOrder: category?.order
+          };
+        });
+      
+      const query = `
+        query GetAllLinkedSkillsWithCategoryOrder($skillName: String!) {
+          linkedSkills(skillName: $skillName) {
+            name
+            category {
+              name
+              order
+            }
+          }
+        }
+      `;
+      
+      const result = await server.executeOperation({
+        query,
+        variables: { skillName },
+      });
+      
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.linkedSkills).toHaveLength(expectedLinkedSkills.length);
+      
+      // Check each linked skill has its category order correctly set
+      result.data?.linkedSkills.forEach((skill: any) => {
+        const expectedSkill = expectedLinkedSkills.find(e => e.name === skill.name);
+        expect(skill.category.name).toBe(expectedSkill?.categoryName);
+        expect(skill.category.order).toBe(expectedSkill?.categoryOrder);
+      });
+    });
   });
   
   describe('Nested resolvers', () => {
-    test('Skill.category resolver returns the category a skill belongs to', async () => {
+    test('Skill.category resolver returns the category a skill belongs to with order field', async () => {
       const skillName = '裏拳';
-      const expectedCategoryName = testSkills.find(s => s.name === skillName)?.categoryName;
+      const expectedSkill = testSkills.find(s => s.name === skillName);
+      const expectedCategoryName = expectedSkill?.categoryName;
+      const expectedCategory = testCategories.find(c => c.name === expectedCategoryName);
       
       const query = `
         query GetSkillWithCategory($name: String!) {
@@ -207,6 +262,7 @@ describe('GraphQL Schema', () => {
             name
             category {
               name
+              order
             }
           }
         }
@@ -220,6 +276,7 @@ describe('GraphQL Schema', () => {
       expect(result.errors).toBeUndefined();
       expect(result.data?.skill.category).not.toBeNull();
       expect(result.data?.skill.category.name).toBe(expectedCategoryName);
+      expect(result.data?.skill.category.order).toBe(expectedCategory?.order);
     });
     
     test('Skill.linksTo resolver returns skills that a skill links to', async () => {

--- a/backend/src/test/mock/repositoryMock.ts
+++ b/backend/src/test/mock/repositoryMock.ts
@@ -32,26 +32,48 @@ export function setupRepositoryMocks() {
     if (categoryName) {
       filteredSkills = testSkills.filter(skill => skill.categoryName === categoryName);
     }
-    return filteredSkills.map(skill => ({ 
-      name: skill.name, 
-      linksTo: [] 
-    }));
+    return filteredSkills.map(skill => {
+      const category = testCategories.find(c => c.name === skill.categoryName);
+      return { 
+        name: skill.name, 
+        linksTo: [],
+        category: {
+          name: skill.categoryName,
+          order: category?.order || 0,
+          skills: []
+        }
+      };
+    });
   });
 
   jest.spyOn(repository, 'findSkillByName').mockImplementation(async (name: string): Promise<SkillType | null> => {
     const skill = testSkills.find(s => s.name === name);
     if (!skill) return null;
+    
+    const category = testCategories.find(c => c.name === skill.categoryName);
     return { 
       name: skill.name, 
-      linksTo: [] 
+      linksTo: [],
+      category: {
+        name: skill.categoryName,
+        order: category?.order || 0,
+        skills: []
+      }
     };
   });
 
   jest.spyOn(repository, 'findSkillsForCategory').mockImplementation(async (categoryName: string): Promise<SkillType[]> => {
     const skills = testSkills.filter(skill => skill.categoryName === categoryName);
+    const category = testCategories.find(c => c.name === categoryName);
+    
     return skills.map(skill => ({ 
       name: skill.name, 
-      linksTo: [] 
+      linksTo: [],
+      category: {
+        name: categoryName,
+        order: category?.order || 0,
+        skills: []
+      }
     }));
   });
 
@@ -74,10 +96,18 @@ export function setupRepositoryMocks() {
     const targetSkillNames = links.map(link => link.targetSkill);
     const linkedSkills = testSkills.filter(skill => targetSkillNames.includes(skill.name));
     
-    return linkedSkills.map(skill => ({ 
-      name: skill.name, 
-      linksTo: [] 
-    }));
+    return linkedSkills.map(skill => {
+      const category = testCategories.find(c => c.name === skill.categoryName);
+      return { 
+        name: skill.name, 
+        linksTo: [],
+        category: {
+          name: skill.categoryName,
+          order: category?.order || 0,
+          skills: []
+        }
+      };
+    });
   });
 
   jest.spyOn(repository, 'findSkillsLinkedTo').mockImplementation(async (skillName: string): Promise<SkillType[]> => {
@@ -85,10 +115,18 @@ export function setupRepositoryMocks() {
     const sourceSkillNames = links.map(link => link.sourceSkill);
     const linkedSkills = testSkills.filter(skill => sourceSkillNames.includes(skill.name));
     
-    return linkedSkills.map(skill => ({ 
-      name: skill.name, 
-      linksTo: [] 
-    }));
+    return linkedSkills.map(skill => {
+      const category = testCategories.find(c => c.name === skill.categoryName);
+      return { 
+        name: skill.name, 
+        linksTo: [],
+        category: {
+          name: skill.categoryName,
+          order: category?.order || 0,
+          skills: []
+        }
+      };
+    });
   });
 
   jest.spyOn(repository, 'findLinkedFromCategories').mockImplementation(async (skillName: string): Promise<CategoryType[]> => {

--- a/frontend/src/api/graphql/queries.ts
+++ b/frontend/src/api/graphql/queries.ts
@@ -45,6 +45,7 @@ export const GET_LINKED_SKILLS_BY_CATEGORY = gql`
         name
         category {
           name
+          order
         }
         linksTo {
           name

--- a/frontend/src/api/hooks/__tests__/useAllSkills.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useAllSkills.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAllSkills, SkillWithCategory } from '../useAllSkills';
+import { ApolloProvider } from '@apollo/client';
+
+describe('useAllSkills', () => {
+  it('スキルがカテゴリのorder順にソートされる', async () => {
+    // モックスキルデータを定義
+    const mockSkills: SkillWithCategory[] = [
+      { name: '剣のスキル', category: '剣', categoryOrder: 3 },
+      { name: '体のスキル', category: '体', categoryOrder: 1 },
+      { name: '槍のスキル', category: '槍', categoryOrder: 4 },
+      { name: '杖のスキル', category: '杖', categoryOrder: 2 }
+    ];
+
+    // モックのカスタムuseAllSkillsフックを作成
+    const mockUseAllSkills = vi.fn().mockReturnValue({
+      loading: false,
+      error: null,
+      allSkills: [...mockSkills].sort((a, b) => 
+        (a.categoryOrder ?? 999) - (b.categoryOrder ?? 999)
+      )
+    });
+
+    // モックフックを使ってテスト
+    const { result } = renderHook(() => mockUseAllSkills());
+
+    // ソート結果の検証
+    const sortedSkills = result.current.allSkills;
+    
+    // データの存在確認
+    expect(sortedSkills.length).toBe(4);
+    
+    // 順序確認（カテゴリorderの昇順）
+    expect(sortedSkills[0].name).toBe('体のスキル');
+    expect(sortedSkills[0].categoryOrder).toBe(1);
+    
+    expect(sortedSkills[1].name).toBe('杖のスキル');
+    expect(sortedSkills[1].categoryOrder).toBe(2);
+    
+    expect(sortedSkills[2].name).toBe('剣のスキル');
+    expect(sortedSkills[2].categoryOrder).toBe(3);
+    
+    expect(sortedSkills[3].name).toBe('槍のスキル');
+    expect(sortedSkills[3].categoryOrder).toBe(4);
+  });
+});

--- a/frontend/src/api/hooks/__tests__/useAllSkills.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useAllSkills.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
-import { useAllSkills, SkillWithCategory } from '../useAllSkills';
-import { ApolloProvider } from '@apollo/client';
+import { renderHook } from '@testing-library/react';
+import { SkillWithCategory } from '../useAllSkills';
 
 describe('useAllSkills', () => {
   it('スキルがカテゴリのorder順にソートされる', async () => {

--- a/frontend/src/api/hooks/useAllSkills.ts
+++ b/frontend/src/api/hooks/useAllSkills.ts
@@ -7,6 +7,7 @@ import { CategoriesQueryResult, CategoryQueryResult } from '../types';
 export interface SkillWithCategory {
   name: string;
   category?: string;
+  categoryOrder?: number;
 }
 
 export function useAllSkills() {
@@ -45,15 +46,17 @@ export function useAllSkills() {
         
         results.forEach((result, index) => {
           const category = categoriesData.categories[index];
+          const categoryOrder = category.order ?? 999; // orderがない場合は大きな値をデフォルトとする
           
           if (result.status === 'fulfilled' && result.value.data?.category?.skills) {
             const formattedSkills = result.value.data.category.skills.map(skill => ({
               name: skill.name,
-              category: category.name
+              category: category.name,
+              categoryOrder: categoryOrder
             }));
             
             allSkillsList.push(...formattedSkills);
-            console.log(`カテゴリ「${category.name}」のスキル ${formattedSkills.length}件を追加`);
+            console.log(`カテゴリ「${category.name}」(order: ${categoryOrder})のスキル ${formattedSkills.length}件を追加`);
           } else if (result.status === 'rejected') {
             console.error(`カテゴリ「${category.name}」のスキル取得エラー:`, result.reason);
           }

--- a/frontend/src/api/hooks/useLinkedSkills.ts
+++ b/frontend/src/api/hooks/useLinkedSkills.ts
@@ -31,12 +31,9 @@ export function useLinkedSkills(sourceSkillName: string | null, categoryName: st
   const error = errorWithCategory || errorWithoutCategory;
   
   // データソースの選択
-  let linkedSkills = [];
-  if (categoryName) {
-    linkedSkills = dataWithCategory?.skill?.linksTo || [];
-  } else {
-    linkedSkills = dataWithoutCategory?.linkedSkills || [];
-  }
+  const linkedSkills = categoryName 
+    ? dataWithCategory?.skill?.linksTo || [] 
+    : dataWithoutCategory?.linkedSkills || [];
   
   return {
     loading,

--- a/frontend/src/features/skillChaining/graph/utils/graphLayout.ts
+++ b/frontend/src/features/skillChaining/graph/utils/graphLayout.ts
@@ -8,8 +8,9 @@ export interface CircleLayoutOptions {
 
 /**
  * 円形レイアウトを計算するユーティリティ関数
+ * 配列の順序を保持するように設計
  * 
- * @param items 配置する要素の配列
+ * @param items 配置する要素の配列（カテゴリ順にソート済み）
  * @param index 現在の要素のインデックス
  * @param options レイアウトオプション
  * @returns {x, y} 座標
@@ -28,7 +29,12 @@ export function calculateCircleLayout<T>(
   } = options;
   
   const total = items.length;
-  const angle = (index * 2 * Math.PI) / total;
+  
+  // 0時方向（上）から時計回りに配置
+  // 最初の要素（インデックス0）を12時の位置（角度 = -π/2）に配置
+  const startAngle = -Math.PI / 2;
+  const angle = startAngle + (index * 2 * Math.PI) / total;
+  
   const radius = Math.max(minRadius, baseRadius + total * increment);
   
   return {

--- a/frontend/src/features/skillChaining/skills/components/SkillFlowChart.tsx
+++ b/frontend/src/features/skillChaining/skills/components/SkillFlowChart.tsx
@@ -81,10 +81,12 @@ export function SkillFlowChart({
     if (selectedCategories.length === 0) return linkedSkills;
     
     // 選択されたカテゴリに属するスキルのみをフィルタリング
-    return linkedSkills.filter(skill => {
+    const filtered = linkedSkills.filter(skill => {
       const skillCategory = skill.category?.name || '';
       return selectedCategories.includes(skillCategory);
     });
+    
+    return filtered;
   }, [linkedSkills, selectedCategories]);
   
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
@@ -93,12 +95,6 @@ export function SkillFlowChart({
   
     // スキルデータからノードとエッジを生成
   useEffect(() => {
-    console.log('スキル名:', sourceSkillName);
-    console.log('選択カテゴリ:', selectedCategories);
-    console.log('連携スキルデータ:', JSON.stringify(linkedSkills, null, 2));
-    console.log('フィルタリング後のスキル数:', filteredSkills.length);
-    console.log('ローディング状態:', loading);
-    console.log('エラー状態:', error?.message);
     
     // データチェック: 空の場合や読み込み中は処理しない
     if (loading) return;
@@ -138,18 +134,6 @@ export function SkillFlowChart({
       return true;
     });
     
-    console.log('有効なスキル数:', validLinkedSkills.length);
-    console.log('フィルタリング状態:', selectedCategories.length > 0 ? 'カテゴリでフィルター中' : 'フィルターなし');
-    
-    // スキルごとの詳細情報をログに出力
-    validLinkedSkills.forEach((targetSkill, index) => {
-      console.log(`スキル ${index + 1}:`, {
-        名前: targetSkill.name,
-        カテゴリ: targetSkill.category?.name || 'カテゴリなし',
-        データ構造: JSON.stringify(targetSkill)
-      });
-    });
-    
     const newNodes: Node[] = [];
     const newEdges: Edge[] = [];
     
@@ -179,8 +163,6 @@ export function SkillFlowChart({
       // カテゴリーに基づいて色を設定
       const targetSkillCategory = targetSkill.category?.name || '';
       const colors = getCategoryColor(targetSkillCategory);
-      
-      console.log(`スキル "${targetSkill.name}" のカテゴリ: ${targetSkillCategory}, 色: ${colors.bg}`);
       
       // スキル名は一意なので、そのままIDとして使用
       const targetSkillName = targetSkill.name;
@@ -286,7 +268,6 @@ export function SkillFlowChart({
       // ノードデータからスキル名を取得（IDからではなく）
       const clickedSkillName = node.data?.label;
       if (typeof clickedSkillName === 'string') {
-        console.log(`スキル選択: ${clickedSkillName}`);
         
         // ノードのIDに「source_」が含まれているかで判断
         const shouldAddToChain = !node.id.toString().startsWith('source_');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skills and linked skills now display their associated category's order information throughout the application.

- **Bug Fixes**
  - Ensured that skills are sorted by their category order in relevant views.

- **Style**
  - Adjusted the circular layout so that the first element appears at the top (12 o’clock position) for improved visual alignment.

- **Tests**
  - Expanded and added tests to verify category order handling and sorting in skills and linked skills.
  - Added tests to confirm skills returned by hooks are sorted by category order.

- **Chores**
  - Removed debug console logs for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->