### PR TITLE
feat: add backend support for skill linked names

### DIFF
--- a/backend/src/infrastructure/neo4jRepository.ts
+++ b/backend/src/infrastructure/neo4jRepository.ts
@@ -68,12 +68,16 @@ const toSkillType = (data: Record<string, unknown> | null): SkillType | null => 
   
   const name = data.name as string;
   const type = data.type as 'waza' | 'jutsuwaza' | 'jutsu' || 'waza';
+  const nonFinalName = data.nonFinalName as string | undefined;
+  const finalName = data.finalName as string | undefined;
   
   if (type === 'waza') {
     return {
       type: 'waza',
       name: name,
       wp: typeof data.wp === 'number' ? data.wp as number : 0,
+      nonFinalName: nonFinalName,
+      finalName: finalName,
       linksTo: [] // NOTE: Empty array is intentional. LinkTo relationships are loaded on-demand
                // by the GraphQL resolver in schema.ts (Skill.linksTo resolver) rather than eagerly loaded here.
     };
@@ -82,6 +86,8 @@ const toSkillType = (data: Record<string, unknown> | null): SkillType | null => 
       type: 'jutsuwaza',
       name: name,
       jp: typeof data.jp === 'number' ? data.jp as number : 0,
+      nonFinalName: nonFinalName,
+      finalName: finalName,
       linksTo: []
     };
   } else { // jutsu
@@ -89,6 +95,8 @@ const toSkillType = (data: Record<string, unknown> | null): SkillType | null => 
       type: 'jutsu',
       name: name,
       jp: typeof data.jp === 'number' ? data.jp as number : 0,
+      nonFinalName: nonFinalName,
+      finalName: finalName,
       linksTo: []
     };
   }

--- a/backend/src/model/Skill.ts
+++ b/backend/src/model/Skill.ts
@@ -9,16 +9,22 @@ export class Skill implements Waza {
   linksTo: SkillType[];
   type: 'waza' = 'waza' as const;
   wp: number;
+  nonFinalName?: string; // Name used at beginning/middle of chain
+  finalName?: string; // Name used at end of chain
 
   constructor(
     name: string, 
     category?: CategoryType, 
     linksTo: SkillType[] = [],
-    wp: number = 0 // デフォルト値
+    wp: number = 0, // デフォルト値
+    nonFinalName?: string,
+    finalName?: string
   ) {
     this.name = name;
     this.category = category;
     this.linksTo = linksTo;
     this.wp = wp;
+    this.nonFinalName = nonFinalName;
+    this.finalName = finalName;
   }
 }

--- a/backend/src/model/types.ts
+++ b/backend/src/model/types.ts
@@ -5,6 +5,8 @@ export interface Skill {
   name: string;
   category?: CategoryType;
   linksTo: SkillType[];
+  nonFinalName?: string; // Name used at beginning/middle of chain
+  finalName?: string; // Name used at end of chain
 }
 
 /**

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -25,6 +25,8 @@ export const typeDefs = gql`
     category: Category # Category this skill belongs to (optional as query might not fetch it)
     linksTo: [Skill!]! # Skills this skill can link to
     linkedBy: [Skill!]! # Skills that can link to this skill
+    nonFinalName: String # Name used at beginning/middle of chain
+    finalName: String # Name used at end of chain
     # linkedCategories: [Category!]! # Categories of skills this skill can link to (distinct) - Derived via query
   }
 

--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -52,7 +52,7 @@
 - [x] feat: default category filter
 - [] feat: show linked name
 - - [x] feat: set up data
-- - [] feat: backend
+- - [x] feat: backend
 - - [] feat: frontend
 - [] feat: show badge when selecting categories
 - [] other: deploy on google cloud


### PR DESCRIPTION
## Summary
- Add GraphQL support for skill linked names (nonFinalName and finalName)
- Update backend models and repository to return linked name properties
- Enable frontend to access skill chain naming data

## Changes
- Added `nonFinalName` and `finalName` fields to GraphQL Skill type
- Updated `Skill` class and `Skill` interface in backend models
- Modified Neo4j repository to fetch linked name properties from database
- Updated TODO.MD to mark backend implementation as complete

## Technical Details
- `nonFinalName`: Used for skill names at the beginning or middle of a chain
- `finalName`: Used for skill names at the end of a chain
- Properties are optional and return null/empty string when not set
- Data comes from the migration added in PR #50

## Test plan
- [x] Verify GraphQL schema includes new fields
- [x] Test GraphQL queries return linked name properties
- [x] Confirm backend models support the new properties
- [x] Validate repository fetches data from Neo4j

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added two new optional fields, "nonFinalName" and "finalName," to skills, allowing display of alternative names for different positions in a skill chain.
- **Documentation**
	- Updated task list to mark the backend feature for showing linked names as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->