### PR TITLE
feat: add frontend support for skill linked names

### DIFF
--- a/frontend/src/api/graphql/queries.ts
+++ b/frontend/src/api/graphql/queries.ts
@@ -18,6 +18,8 @@ export const GET_SKILLS_BY_CATEGORY = gql`
       order
       skills {
         name
+        nonFinalName
+        finalName
       }
     }
   }
@@ -28,6 +30,8 @@ export const GET_SKILL_LINKED_CATEGORIES = gql`
   query GetSkillLinkedCategories($skillName: String!) {
     skill(name: $skillName) {
       name
+      nonFinalName
+      finalName
     }
     linkedFromCategories(skillName: $skillName) {
       name
@@ -41,14 +45,20 @@ export const GET_LINKED_SKILLS_BY_CATEGORY = gql`
   query GetLinkedSkillsByCategory($skillName: String!, $categoryName: String!) {
     skill(name: $skillName) {
       name
+      nonFinalName
+      finalName
       linksTo {
         name
+        nonFinalName
+        finalName
         category {
           name
           order
         }
         linksTo {
           name
+          nonFinalName
+          finalName
         }
       }
     }
@@ -64,12 +74,16 @@ export const GET_LINKED_SKILLS = gql`
   query GetLinkedSkills($skillName: String!) {
     linkedSkills(skillName: $skillName) {
       name
+      nonFinalName
+      finalName
       category {
         name
         order
       }
       linksTo {
         name
+        nonFinalName
+        finalName
       }
     }
   }

--- a/frontend/src/api/hooks/__tests__/useCategories.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useCategories.test.tsx
@@ -7,11 +7,11 @@ import { useCategories } from '../useCategories';
 describe('useCategories', () => {
   // テスト用のカテゴリデータ
   const TEST_CATEGORIES = [
-    { name: '体' },
-    { name: '剣' },
-    { name: '斧' },
-    { name: '杖' },
-    { name: '槍' }
+    { name: '体', order: 1 },
+    { name: '剣', order: 3 },
+    { name: '斧', order: 5 },
+    { name: '杖', order: 6 },
+    { name: '槍', order: 7 }
   ];
 
   // 成功時のモックレスポンス

--- a/frontend/src/api/hooks/__tests__/useLinkedCategories.test.tsx
+++ b/frontend/src/api/hooks/__tests__/useLinkedCategories.test.tsx
@@ -8,8 +8,8 @@ describe('useLinkedCategories', () => {
   // テスト用のスキルとリンクカテゴリデータ
   const TEST_SKILL_NAME = '裏拳';
   const TEST_LINKED_CATEGORIES = [
-    { name: '体' },
-    { name: '剣' }
+    { name: '体', order: 1 },
+    { name: '剣', order: 3 }
   ];
 
   // 成功時のモックレスポンス
@@ -20,7 +20,11 @@ describe('useLinkedCategories', () => {
     },
     result: {
       data: {
-        skill: { name: TEST_SKILL_NAME },
+        skill: { 
+          name: TEST_SKILL_NAME,
+          nonFinalName: '裏',
+          finalName: '裏拳'
+        },
         linkedFromCategories: TEST_LINKED_CATEGORIES
       }
     }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,6 +11,8 @@ export interface Skill {
   category?: Category;
   linksTo?: Skill[];
   linkedBy?: Skill[];
+  nonFinalName?: string; // Name used at beginning/middle of chain
+  finalName?: string; // Name used at end of chain
 }
 
 // Query result types

--- a/frontend/src/features/skillChaining/skills/hooks/__tests__/useSkillGraph.test.tsx
+++ b/frontend/src/features/skillChaining/skills/hooks/__tests__/useSkillGraph.test.tsx
@@ -17,13 +17,32 @@ describe('useSkillGraph', () => {
   const mockLinkedSkills = [
     {
       name: '胴抜き',
+      nonFinalName: '胴',
+      finalName: '抜き',
       category: { name: '体', order: 1 },
-      linksTo: [{ name: '熊掌打' }],
+      linksTo: [{ 
+        name: '熊掌打',
+        nonFinalName: '熊',
+        finalName: '掌打'
+      }],
     },
     {
       name: '切り返し',
+      nonFinalName: '返し',
+      finalName: '返し',
       category: { name: '剣', order: 3 },
-      linksTo: [{ name: '十字切り' }, { name: '大木断' }],
+      linksTo: [
+        { 
+          name: '十字切り',
+          nonFinalName: '十字',
+          finalName: '切り'
+        }, 
+        { 
+          name: '大木断',
+          nonFinalName: '大木',
+          finalName: '断'
+        }
+      ],
     },
   ];
 


### PR DESCRIPTION
## Summary
- Update frontend to receive and handle skill linked name properties from GraphQL API
- Fix Apollo Client warnings in tests by adding missing fields to mock data
- Prepare frontend for displaying skill chain combination names

## Changes
- Added `nonFinalName` and `finalName` properties to Skill interface
- Updated all GraphQL queries to include the new linked name fields
- Enhanced test mock data with realistic linked name values
- Added missing `order` field to category mock data

## Dependencies
- Depends on backend changes from PR #51 (must be merged first)
- Works with data from migration in PR #50

## Technical Details
- `nonFinalName`: Skill name used at the beginning or middle of a chain
- `finalName`: Skill name used at the end of a chain
- All properties are optional to maintain backward compatibility

## Test plan
- [x] TypeScript compilation passes
- [x] All frontend tests pass without warnings
- [x] Apollo Client no longer shows missing field warnings
- [ ] Manual testing with backend API (after backend PR is merged)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying alternative skill names (`nonFinalName` and `finalName`) throughout the app, allowing for more detailed skill information.

- **Tests**
  - Updated test data for categories and skills to include new fields and properties, ensuring comprehensive test coverage for the enhanced skill naming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->