### PR TITLE
feat: display combined skill names during chaining

### DIFF
--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -50,11 +50,11 @@
 - - [x] update README with architecture patterns
 - [x] fix: batch number are too large
 - [x] feat: default category filter
-- [] feat: show linked name
+- [x] feat: show linked name
 - - [x] feat: set up data
 - - [x] feat: backend
 - - [x] feat: frontend query
-- - [] feat: frontend ui
+- - [x] feat: frontend ui
 - [] feat: show badge when selecting categories
 - [] other: deploy on google cloud
 - - [] other: deploy on cloud run

--- a/frontend/src/api/hooks/useAllSkills.ts
+++ b/frontend/src/api/hooks/useAllSkills.ts
@@ -8,6 +8,8 @@ export interface SkillWithCategory {
   name: string;
   category?: string;
   categoryOrder?: number;
+  nonFinalName?: string;
+  finalName?: string;
 }
 
 export function useAllSkills() {
@@ -52,7 +54,9 @@ export function useAllSkills() {
             const formattedSkills = result.value.data.category.skills.map(skill => ({
               name: skill.name,
               category: category.name,
-              categoryOrder: categoryOrder
+              categoryOrder: categoryOrder,
+              nonFinalName: skill.nonFinalName,
+              finalName: skill.finalName
             }));
             
             allSkillsList.push(...formattedSkills);

--- a/frontend/src/features/skillChaining/skills/stacking/StackedSkills.tsx
+++ b/frontend/src/features/skillChaining/skills/stacking/StackedSkills.tsx
@@ -2,9 +2,11 @@ import React, { useCallback } from 'react';
 import { useSkillStack } from '@features/skillChaining/state/SkillStackContext';
 import { getCategoryColor } from '@features/skillChaining/categories/hooks/categoryColors';
 import { SkillItem, OnSkillSelectCallback } from '@features/skillChaining/types';
+import { generateChainName } from '../utils/skillChainNameUtils';
+import { Skill } from '@api/types';
 
 interface StackedSkillsProps {
-  allSkills: SkillItem[];
+  allSkills: (SkillItem & Partial<Skill>)[];
   onSkillClick?: OnSkillSelectCallback;
 }
 
@@ -12,7 +14,7 @@ export function StackedSkills({ allSkills, onSkillClick }: StackedSkillsProps) {
   const { state: { selectedSkills }, dispatch } = useSkillStack();
   
   // 選択されたスキルの詳細情報を取得
-  const selectedSkillDetails: SkillItem[] = selectedSkills.map(skillName => {
+  const selectedSkillDetails: (SkillItem & Partial<Skill>)[] = selectedSkills.map(skillName => {
     const foundSkill = allSkills.find(skill => skill.name === skillName);
     if (foundSkill) {
       return foundSkill;
@@ -23,6 +25,9 @@ export function StackedSkills({ allSkills, onSkillClick }: StackedSkillsProps) {
       category: 'default'
     };
   });
+  
+  // 連携名を生成
+  const chainName = generateChainName(selectedSkillDetails as Skill[]);
   
   // スキルクリックハンドラー - useCallbackでメモ化して不要な再作成を防止
   const handleSkillClick = useCallback((skillName: string, index: number) => {
@@ -42,7 +47,7 @@ export function StackedSkills({ allSkills, onSkillClick }: StackedSkillsProps) {
   
   return (
     <div className="stacked-skills-container">
-      <h3>連携</h3>
+      <h3>連携{chainName && `: ${chainName}`}</h3>
       <div className="stacked-skills-list">
         {selectedSkillDetails.map((skill: SkillItem, index) => {
           // カテゴリ名を取得（文字列または未定義の場合はデフォルト値を使用）

--- a/frontend/src/features/skillChaining/skills/utils/__tests__/skillChainNameUtils.test.ts
+++ b/frontend/src/features/skillChaining/skills/utils/__tests__/skillChainNameUtils.test.ts
@@ -9,8 +9,8 @@ describe('skillChainNameUtils', () => {
     });
 
     it('nullまたはundefinedの場合は空文字を返す', () => {
-      expect(generateChainName(null as any)).toBe('');
-      expect(generateChainName(undefined as any)).toBe('');
+      expect(generateChainName(null as unknown as Skill[])).toBe('');
+      expect(generateChainName(undefined as unknown as Skill[])).toBe('');
     });
 
     it('単体スキルの場合はそのままスキル名を返す', () => {
@@ -190,8 +190,8 @@ describe('skillChainNameUtils', () => {
     });
 
     it('nullまたはundefinedの場合はfalseを返す', () => {
-      expect(allHaveChainNameData(null as any)).toBe(false);
-      expect(allHaveChainNameData(undefined as any)).toBe(false);
+      expect(allHaveChainNameData(null as unknown as Skill[])).toBe(false);
+      expect(allHaveChainNameData(undefined as unknown as Skill[])).toBe(false);
     });
   });
 });

--- a/frontend/src/features/skillChaining/skills/utils/__tests__/skillChainNameUtils.test.ts
+++ b/frontend/src/features/skillChaining/skills/utils/__tests__/skillChainNameUtils.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { generateChainName, hasChainNameData, allHaveChainNameData } from '../skillChainNameUtils';
+import { Skill } from '@api/types';
+
+describe('skillChainNameUtils', () => {
+  describe('generateChainName', () => {
+    it('空の配列の場合は空文字を返す', () => {
+      expect(generateChainName([])).toBe('');
+    });
+
+    it('nullまたはundefinedの場合は空文字を返す', () => {
+      expect(generateChainName(null as any)).toBe('');
+      expect(generateChainName(undefined as any)).toBe('');
+    });
+
+    it('単体スキルの場合はそのままスキル名を返す', () => {
+      const skill: Skill = {
+        name: '胴抜き',
+        nonFinalName: '胴',
+        finalName: '抜き'
+      };
+      expect(generateChainName([skill])).toBe('胴抜き');
+    });
+
+    it('2つのスキルの連携名を正しく生成する', () => {
+      const skills: Skill[] = [
+        {
+          name: '胴抜き',
+          nonFinalName: '胴',
+          finalName: '抜き'
+        },
+        {
+          name: '熊掌打',
+          nonFinalName: '熊',
+          finalName: '掌打'
+        }
+      ];
+      expect(generateChainName(skills)).toBe('胴掌打');
+    });
+
+    it('3つのスキルの連携名を正しく生成する', () => {
+      const skills: Skill[] = [
+        {
+          name: '切り返し',
+          nonFinalName: '返し',
+          finalName: '返し'
+        },
+        {
+          name: '十字斬り',
+          nonFinalName: '十字',
+          finalName: '十字'
+        },
+        {
+          name: '大木断',
+          nonFinalName: '大木',
+          finalName: '断'
+        }
+      ];
+      expect(generateChainName(skills)).toBe('返し十字断');
+    });
+
+    it('連携名データがないスキルの場合は元の名前を使用する', () => {
+      const skills: Skill[] = [
+        {
+          name: '裏拳'
+          // nonFinalName, finalNameがない
+        },
+        {
+          name: 'キックラッシュ'
+          // nonFinalName, finalNameがない
+        }
+      ];
+      expect(generateChainName(skills)).toBe('裏拳キックラッシュ');
+    });
+
+    it('一部のスキルのみ連携名データがある場合', () => {
+      const skills: Skill[] = [
+        {
+          name: '胴抜き',
+          nonFinalName: '胴',
+          finalName: '抜き'
+        },
+        {
+          name: 'キックラッシュ'
+          // nonFinalName, finalNameがない
+        },
+        {
+          name: '熊掌打',
+          nonFinalName: '熊',
+          finalName: '掌打'
+        }
+      ];
+      expect(generateChainName(skills)).toBe('胴キックラッシュ掌打');
+    });
+
+    it('finalNameが空文字の場合', () => {
+      const skills: Skill[] = [
+        {
+          name: '残像剣',
+          nonFinalName: '残像',
+          finalName: ''
+        },
+        {
+          name: '剣風閃',
+          nonFinalName: '剣風',
+          finalName: ''
+        }
+      ];
+      // 最後のスキルのfinalNameが空の場合は元の名前を使用
+      expect(generateChainName(skills)).toBe('残像剣風閃');
+    });
+  });
+
+  describe('hasChainNameData', () => {
+    it('連携名データがある場合はtrueを返す', () => {
+      const skill: Skill = {
+        name: '胴抜き',
+        nonFinalName: '胴',
+        finalName: '抜き'
+      };
+      expect(hasChainNameData(skill)).toBe(true);
+    });
+
+    it('nonFinalNameのみある場合もtrueを返す', () => {
+      const skill: Skill = {
+        name: '残像剣',
+        nonFinalName: '残像'
+      };
+      expect(hasChainNameData(skill)).toBe(true);
+    });
+
+    it('finalNameのみある場合もtrueを返す', () => {
+      const skill: Skill = {
+        name: 'デッドエンド',
+        finalName: 'エンド'
+      };
+      expect(hasChainNameData(skill)).toBe(true);
+    });
+
+    it('連携名データがない場合はfalseを返す', () => {
+      const skill: Skill = {
+        name: 'キックラッシュ'
+      };
+      expect(hasChainNameData(skill)).toBe(false);
+    });
+
+    it('両方とも空文字の場合はfalseを返す', () => {
+      const skill: Skill = {
+        name: 'テスト',
+        nonFinalName: '',
+        finalName: ''
+      };
+      expect(hasChainNameData(skill)).toBe(false);
+    });
+  });
+
+  describe('allHaveChainNameData', () => {
+    it('全てのスキルが連携名データを持つ場合はtrueを返す', () => {
+      const skills: Skill[] = [
+        {
+          name: '胴抜き',
+          nonFinalName: '胴',
+          finalName: '抜き'
+        },
+        {
+          name: '熊掌打',
+          nonFinalName: '熊',
+          finalName: '掌打'
+        }
+      ];
+      expect(allHaveChainNameData(skills)).toBe(true);
+    });
+
+    it('一部のスキルが連携名データを持たない場合はfalseを返す', () => {
+      const skills: Skill[] = [
+        {
+          name: '胴抜き',
+          nonFinalName: '胴',
+          finalName: '抜き'
+        },
+        {
+          name: 'キックラッシュ'
+        }
+      ];
+      expect(allHaveChainNameData(skills)).toBe(false);
+    });
+
+    it('空の配列の場合はfalseを返す', () => {
+      expect(allHaveChainNameData([])).toBe(false);
+    });
+
+    it('nullまたはundefinedの場合はfalseを返す', () => {
+      expect(allHaveChainNameData(null as any)).toBe(false);
+      expect(allHaveChainNameData(undefined as any)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/features/skillChaining/skills/utils/skillChainNameUtils.ts
+++ b/frontend/src/features/skillChaining/skills/utils/skillChainNameUtils.ts
@@ -1,0 +1,55 @@
+import { Skill } from '@api/types';
+
+/**
+ * スキルの連携名を生成する
+ * @param skills - 連携するスキルの配列
+ * @returns 連携名の文字列
+ */
+export function generateChainName(skills: Skill[]): string {
+  if (!skills || skills.length === 0) {
+    return '';
+  }
+
+  if (skills.length === 1) {
+    // 単体スキルの場合はそのまま名前を返す
+    return skills[0].name;
+  }
+
+  // 連携名を構築
+  const chainParts: string[] = [];
+  
+  skills.forEach((skill, index) => {
+    const isLast = index === skills.length - 1;
+    
+    if (isLast) {
+      // 最後のスキルはfinalNameを使用
+      chainParts.push(skill.finalName || skill.name);
+    } else {
+      // それ以外はnonFinalNameを使用
+      chainParts.push(skill.nonFinalName || skill.name);
+    }
+  });
+
+  return chainParts.join('');
+}
+
+/**
+ * スキルが連携名データを持っているかチェック
+ * @param skill - チェックするスキル
+ * @returns 連携名データの有無
+ */
+export function hasChainNameData(skill: Skill): boolean {
+  return !!(skill.nonFinalName || skill.finalName);
+}
+
+/**
+ * 複数のスキルが全て連携名データを持っているかチェック
+ * @param skills - チェックするスキルの配列
+ * @returns 全てのスキルが連携名データを持っているか
+ */
+export function allHaveChainNameData(skills: Skill[]): boolean {
+  if (!skills || skills.length === 0) {
+    return false;
+  }
+  return skills.every(skill => hasChainNameData(skill));
+}


### PR DESCRIPTION
## Summary
- Complete frontend implementation for displaying combined skill names during chaining
- Skills now show their linked names based on position in the chain (nonFinalName for non-final positions, finalName for last position)

## Changes
- Add `generateChainName` utility function to combine skill names based on their position
- Update `useAllSkills` hook to fetch `nonFinalName` and `finalName` properties from GraphQL
- Integrate chain name display in `StackedSkills` component header
- Add comprehensive unit tests for chain name generation logic
- Update TODO.MD to mark feature as complete

## Test plan
- [x] Unit tests for skillChainNameUtils pass
- [ ] Frontend displays combined skill names correctly when chaining skills
- [ ] Chain names update dynamically as skills are added/removed
- [ ] Fallback to original names works when linked names are not available

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skill chaining UI now displays a generated chain name based on selected skills.
  - Added support for additional skill name properties, allowing more flexible naming in skill lists.

- **Bug Fixes**
  - Improved handling of skills with missing or partial chain name data in the skill chaining interface.

- **Tests**
  - Introduced comprehensive tests for skill chain name utilities, ensuring robust name generation and validation.

- **Documentation**
  - Updated TODO list to reflect completed features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->